### PR TITLE
Add option to customize generated cell keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ The plugin is based on the [node-sheets](https://github.com/urbancups/node-sheet
     // The `mapValue(value, key, cell)` function lets you map each cell's value to your need.
     // For example, it can be used to ensure that all strings are trimmed:
     mapValue: value => typeof value === "string" ? value.trim() : value
+    
+    // The `mapKey(key)` function lets you map each cell's key as sometimes the camelcase library does a poor job guessing
+    // the correct key. For example special characters and letters outside ascii might get switched to underscore.
+    mapValue: key => key === 'ääöö' ? 'aaoo' : key
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The plugin is based on the [node-sheets](https://github.com/urbancups/node-sheet
     
     // The `mapKey(key)` function lets you map each cell's key as sometimes the camelcase library does a poor job guessing
     // the correct key. For example special characters and letters outside ascii might get switched to underscore.
-    mapValue: key => key === 'ääöö' ? 'aaoo' : key
+    mapKey: key => key === 'ääöö' ? 'aaoo' : key
   }
 }
 ```

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -9,7 +9,8 @@ exports.sourceNodes = async ({ actions, createNodeId }, pluginOptions) => {
     spreadsheetName = "",
     typePrefix = "GoogleSpreadsheet",
     credentials,
-    mapValue = value => value
+    mapValue = value => value,
+    mapKey = key => camelCase(key)
   } = pluginOptions;
 
   const { createNodeFactory } = createNodeHelpers({
@@ -25,13 +26,12 @@ exports.sourceNodes = async ({ actions, createNodeId }, pluginOptions) => {
   const promises = (await gs.getSheetsNames()).map(async sheetTitle => {
     const tables = await gs.tables(sheetTitle);
     const { rows } = tables;
-
     const buildNode = createNodeFactory(
       camelCase(`${spreadsheetName} ${sheetTitle}`)
     );
     for (let i = 0; i < rows.length; i++) {
       const node = Object.entries(rows[i]).reduce((obj, [key, cell]) => {
-        obj[camelCase(key)] =
+        obj[mapKey(key)] =
           typeof cell === "object" && cell.stringValue !== undefined
             ? mapValue(cell.value, key, cell)
             : null;


### PR DESCRIPTION
Added option to customize each cell's key as sometimes the camelcase library does a poor job guessing the correct key. For example special characters and letters outside ascii might get switched to underscore.